### PR TITLE
chore: document subgraph proxy workflow

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+VITE_SUBGRAPH_PROXY_BASE=https://api.threshold.network
+VITE_SUBGRAPH_PROXY_MAINNET=https://api.threshold.network/subgraph/mainnet
+VITE_SUBGRAPH_PROXY_TESTNET=https://api.threshold.network/subgraph/testnet

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,3 @@
+VITE_SUBGRAPH_PROXY_BASE=https://threshold-api-staging.ops-keep.workers.dev
+VITE_SUBGRAPH_PROXY_MAINNET=https://threshold-api-staging.ops-keep.workers.dev/subgraph/mainnet
+VITE_SUBGRAPH_PROXY_TESTNET=https://threshold-api-staging.ops-keep.workers.dev/subgraph/testnet

--- a/.graphclientrc.yml
+++ b/.graphclientrc.yml
@@ -2,7 +2,7 @@ sources:
   - name: tbtc-mainnet
     handler:
       graphql:
-        endpoint: https://gateway.thegraph.com/api/f49026e5653284c96b9798f93567eaa1/subgraphs/id/DETCX5Xm6tJfctRcZAxhQB9q3aK8P4BXLbujHmzEBXYV
+        endpoint: https://threshold-api-staging.ops-keep.workers.dev/subgraph/mainnet
     transforms:
       - autoPagination:
           limitOfRecords: 2000

--- a/README.md
+++ b/README.md
@@ -7,6 +7,32 @@ It incorporates work from️:
 [@miracle2k](https://github.com/miracle2k): Thanks for his [allthekeep](https://github.com/miracle2k/keep-subgraph) subgraph.
 
 Live at : https://tbtcscan.com/
+
+## Subgraph proxy and codegen
+
+1. Environment files
+   - `.env.production` and `.env.staging` define `VITE_SUBGRAPH_PROXY_BASE` plus explicit overrides `VITE_SUBGRAPH_PROXY_MAINNET` / `VITE_SUBGRAPH_PROXY_TESTNET` for each environment.
+   - `yarn build` uses `.env.production`; `yarn build:staging` uses `.env.staging`. Local dev can override inline, e.g. `VITE_SUBGRAPH_PROXY_BASE=... yarn start`.
+
+2. Codegen endpoint
+   - Graphclient reads its endpoint from `.graphclientrc.yml`; env interpolation was unreliable, so we rewrite that file before codegen/build.
+   - Use `scripts/set-graph-endpoint.sh staging|prod` to set `.graphclientrc.yml` to the correct proxy before `yarn codegen`.
+
+3. Common commands (endpoint + codegen + build)
+   - `yarn start:staging`: set staging endpoint → `yarn codegen` → `yarn build:staging` → `yarn preview`.
+   - `yarn start:prod`: set prod endpoint → `yarn codegen` → `yarn build-prod` → `yarn preview`.
+   - `yarn deploy:staging` / `yarn deploy:prod`: set endpoint → `yarn codegen` → build (no preview). Use these for CI or manual deploys.
+
+4. CORS expectations (proxy side)
+   - Staging proxy allows `http://localhost:4001` for local preview.
+   - Production proxy allows `https://tbtcscan.com` and `https://threshold.network` only.
+
+5. Preflight checklist
+   - Confirm you edited the right env file for the target (`.env.production` or `.env.staging`).
+   - Run `scripts/set-graph-endpoint.sh staging|prod` (or rely on the commands above) so `.graphclientrc.yml` matches the build target.
+   - Run `yarn codegen` after switching endpoints.
+   - (Optional) Run `scripts/which-endpoint.sh` to print the active codegen endpoint and current proxy env values.
+
 ## Installation
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -27,8 +27,13 @@
   },
   "scripts": {
     "start": "export PORT=4001 && vite",
+    "start:staging": "MODE=staging ./scripts/set-graph-endpoint.sh staging && yarn codegen && yarn build:staging && yarn preview",
+    "start:prod": "MODE=production ./scripts/set-graph-endpoint.sh production && yarn codegen && yarn build-prod && yarn preview",
+    "deploy:staging": "MODE=staging ./scripts/set-graph-endpoint.sh staging && yarn codegen && yarn build:staging",
+    "deploy:prod": "MODE=production ./scripts/set-graph-endpoint.sh production && yarn codegen && yarn build-prod",
     "build-prod": "vite build --mode production",
     "build": "vite build",
+    "build:staging": "vite build --mode staging",
     "preview": "vite preview --port 4001",
     "prod": "npm run build && PORT=4001 serve -s build ",
     "codegen": "graphclient build",

--- a/scripts/set-graph-endpoint.sh
+++ b/scripts/set-graph-endpoint.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-staging}"
+
+case "$MODE" in
+  staging)
+    ENDPOINT="https://threshold-api-staging.ops-keep.workers.dev/subgraph/mainnet"
+    ;;
+  production|prod)
+    ENDPOINT="https://api.threshold.network/subgraph/mainnet"
+    ;;
+  *)
+    echo "Usage: $0 [staging|production]" >&2
+    exit 1
+    ;;
+esac
+
+cat > .graphclientrc.yml <<EOF
+sources:
+  - name: tbtc-mainnet
+    handler:
+      graphql:
+        endpoint: $ENDPOINT
+    transforms:
+      - autoPagination:
+          limitOfRecords: 2000
+plugins:
+  - pollingLive:
+      defaultInterval: 1000
+documents:
+  - ./src/pages/query.graphql
+EOF
+
+echo "Wrote .graphclientrc.yml for $MODE ($ENDPOINT)"

--- a/scripts/which-endpoint.sh
+++ b/scripts/which-endpoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f .graphclientrc.yml ]]; then
+  echo ".graphclientrc.yml not found" >&2
+  exit 1
+fi
+
+ENDPOINT=$(grep -E "^\s*endpoint:" .graphclientrc.yml | head -n1 | awk '{print $2}')
+
+echo ".graphclientrc.yml endpoint: ${ENDPOINT:-"(not found)"}"
+echo "VITE_SUBGRAPH_PROXY_BASE=${VITE_SUBGRAPH_PROXY_BASE:-"(unset)"}"
+echo "VITE_SUBGRAPH_PROXY_MAINNET=${VITE_SUBGRAPH_PROXY_MAINNET:-"(unset)"}"
+echo "VITE_SUBGRAPH_PROXY_TESTNET=${VITE_SUBGRAPH_PROXY_TESTNET:-"(unset)"}"

--- a/src/pages/home/about.jsx
+++ b/src/pages/home/about.jsx
@@ -11,9 +11,8 @@ const About = () => {
             <div className={styles.div_bottom}>
                 <a target="_blank" href={"https://github.com/suntzu93/threshold-tBTC"}>[Subgraph code] - </a>
                 <a target="_blank" href={"https://github.com/suntzu93/tbtcv2_website_info"}>[Website code] </a>
-                API (Mainnet : <a target="_blank" href={Const.MAINNET_API}>suntzu93/threshold-tbtc</a> -
-                Testnet : <a target="_blank"
-                             href={Const.TESTNET_API}>suntzu93/tbtcv2</a>)
+                API (Mainnet : <code>{Const.MAINNET_API}</code> -
+                Testnet : <code>{Const.TESTNET_API}</code>)
             </div>
         </div>
 

--- a/src/utils/Cons.jsx
+++ b/src/utils/Cons.jsx
@@ -1,5 +1,18 @@
-export const MAINNET_API = "https://gateway-arbitrum.network.thegraph.com/api/f49026e5653284c96b9798f93567eaa1/subgraphs/id/DETCX5Xm6tJfctRcZAxhQB9q3aK8P4BXLbujHmzEBXYV";
-export const TESTNET_API = "https://api.thegraph.com/subgraphs/name/suntzu93/threshold-tbtc-goerli";
+const fallbackProxyBase =
+  import.meta.env.MODE === "staging"
+    ? "https://threshold-api-staging.ops-keep.workers.dev"
+    : "https://api.threshold.network";
+
+const SUBGRAPH_PROXY_BASE = (
+  import.meta.env.VITE_SUBGRAPH_PROXY_BASE ?? fallbackProxyBase
+).replace(/\/$/, "");
+
+export const MAINNET_API =
+  import.meta.env.VITE_SUBGRAPH_PROXY_MAINNET ??
+  `${SUBGRAPH_PROXY_BASE}/subgraph/mainnet`;
+export const TESTNET_API =
+  import.meta.env.VITE_SUBGRAPH_PROXY_TESTNET ??
+  `${SUBGRAPH_PROXY_BASE}/subgraph/testnet`;
 
 export const RPC_ETH_MAINNET = import.meta.env.VITE_RPC_ETH_MAINNET;
 export const RPC_ETH_GOERLI = "https://eth-goerli.g.alchemy.com/v2/BS3qcnNmATIAa9rI7xFMmpyB-RHg_dAm"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "name": "tbtcscan-website",
   "main": "worker.js",
+  "account_id": "aae90701d7bc564b2670369f6aed0b29",
   "compatibility_date": "2025-12-04",
   "assets": {
     "directory": "./dist"


### PR DESCRIPTION
## Summary
- document subgraph proxy/codegen workflow and CORS expectations
- add env files and scripts to swap graph endpoints and print current config
- add staging/prod start/deploy commands using the proxy and codegen rewrite

## Testing
- not run (docs/scripts only)